### PR TITLE
1 add ethernet support

### DIFF
--- a/DuinoDCX/Config.h
+++ b/DuinoDCX/Config.h
@@ -11,7 +11,7 @@
 #define TX2_PIN 15
 #define RTS_PIN 21
 #define CTS_PIN 22
-#define RESET_PIN 13
+#define RESET_PIN 12
 #define AUTH_KEY "auth"
 #define SOFT_AP_PASSWORD_KEY "apPassword"
 #define SOFT_AP_SSID_KEY "apSsid"
@@ -32,3 +32,12 @@
 #define MDDNS_NAME_LENGTH 65
 
 #define ETH_DBGPRINT_INTERVAL 10000
+#define ETH_DEFAULT_USE_DHCP true
+#define ETH_DEFAULT_IP "192.168.1.2"
+#define ETH_IP_LENGTH 15
+#define ETH_DEFAULT_GW "192.168.1.1"
+#define ETH_DEFAULT_NET "255.255.255.0"
+#define ETH_USE_DHCP_KEY "ethUseDhcp"
+#define ETH_IP_KEY "ethIp"
+#define ETH_GW_KEY "ethGw"
+#define ETH_NET_KEY "ethNet"

--- a/DuinoDCX/Config.h
+++ b/DuinoDCX/Config.h
@@ -7,8 +7,8 @@
 #define WIFI_HOST_NAME "ultradrive"
 #define DEFAULT_FLOW_CONTROL false
 #define DEFAULT_AUTO_DISABLE_AP false
-#define RX2_PIN 16
-#define TX2_PIN 17
+#define RX2_PIN 14
+#define TX2_PIN 15
 #define RTS_PIN 21
 #define CTS_PIN 22
 #define RESET_PIN 13
@@ -30,3 +30,5 @@
 #define SOFT_AP_SSID_LENGTH 65
 #define SOFT_AP_PASSWORD_LENGTH 65
 #define MDDNS_NAME_LENGTH 65
+
+#define ETH_DBGPRINT_INTERVAL 10000


### PR DESCRIPTION
Settings can be updated using the following PATCH request body
```json
{
	"apSsid": "DCX2496",
	"apPassword": "Ultradrive",
	"mdnsHost": "ultradrive",
	"flowControl": "0",
	"autoDisableAP": "0",
	"ethIp": "192.168.2.50",
	"ethUseDhcp": "0",
	"ethGw": "192.168.2.1",
	"ethNet": "255.255.255.0",
	"auth": "Basic+xxx"
}
``` 

Response on serial switching from DHCP
```
Event: Ethernet got IP
- - -
IP configuration: DHCP
Ethernet MAC: 4C:C3:82:0C:E2:1B
Ethernet connected
Ethernet link up
Ethernet full duplex
Speed: 100 MBit/s
Ethernet local IP: 192.168.2.188
*eth0: <UP,100M,FULL_DUPLEX,AUTO,ADDR:0x1> (DHCPC,GARP,IP_MOD) PRIO: 50
      ether 4C:C3:82:0C:E2:1B
      inet 192.168.2.188 netmask 255.255.255.0 broadcast 192.168.2.255
      gateway 192.168.2.1 dns 192.168.2.1
```

to static
```
Event: Ethernet started
Event: Ethernet connected
Event: Ethernet got IP
- - -
IP configuration: static
Static IP Configuration: 192.168.2.50
Static Gateway Configuration: 192.168.2.1
Static Subnet Configuration: 255.255.255.0
Ethernet MAC: 4C:C3:82:0C:E2:1B
Ethernet connected
Ethernet link up
Ethernet full duplex
Speed: 100 MBit/s
Ethernet local IP: 192.168.2.50
*eth0: <UP,100M,FULL_DUPLEX,AUTO,ADDR:0x1> (DHCPC_OFF,GARP,IP_MOD) PRIO: 50
      ether 4C:C3:82:0C:E2:1B
      inet 192.168.2.50 netmask 255.255.255.0 broadcast 192.168.2.255
      gateway 192.168.2.1 dns 0.0.0.0
```